### PR TITLE
avoid crash when create a 'ones' var from multi-branch var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(AnalysisTreeQA_BUILD_TASKS OFF CACHE BOOL "Build user' AnalysisTreeQA tasks 
 set(AnalysisTreeQA_BUILD_EXAMPLES ON CACHE BOOL "Build AnalysisTreeQA examples (examples/)")
 set(AnalysisTreeQA_BUILD_TESTS OFF CACHE BOOL "Build tests for AnalysisTreeQA")
 set(AnalysisTreeQA_BUNDLED_AT ON CACHE BOOL "Get and build AnalysisTree")
-set(AnalysisTreeQA_BUNDLED_AT_VERSION "v2.3.4" CACHE STRING "Bundled AnalysisTree version")
+set(AnalysisTreeQA_BUNDLED_AT_VERSION "v2.3.5" CACHE STRING "Bundled AnalysisTree version")
 set(AnalysisTreeQA_BUNDLED_AT_GIT_SHALLOW ON CACHE BOOL "Use CMake GIT_SHALLOW option")
 set(AnalysisTreeQA_BUNDLED_CUTS ON CACHE BOOL "Get and build AnalysisTreeCuts")
 set(AnalysisTreeQA_BUNDLED_CUTS_VERSION "v0.0.1" CACHE STRING "Bundled AnalysisTreeCuts version")

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -21,9 +21,7 @@ class Task : public AnalysisTask {
   void Finish() override;
 
   size_t AddH1(const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    if(weight.GetNumberOfBranches() == 0) {
-      weight = Variable::FromString(x.GetBranchName() + ".ones");
-    }
+    weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, weight, cuts, false));
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
@@ -31,9 +29,7 @@ class Task : public AnalysisTask {
   }
 
   size_t AddH2(const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    if(weight.GetNumberOfBranches() == 0) {
-      weight = Variable::FromString(x.GetBranchName() + ".ones");
-    }
+    weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, y, weight, cuts));
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({ {var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)} });
@@ -41,9 +37,7 @@ class Task : public AnalysisTask {
   }
 
   size_t AddProfile(const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    if(weight.GetNumberOfBranches() == 0) {
-      weight = Variable::FromString(x.GetBranchName() + ".ones");
-    }
+    weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, y, weight, cuts, true));
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({ {var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)} });
@@ -51,9 +45,7 @@ class Task : public AnalysisTask {
   }
 
   size_t AddIntegral(const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    if(weight.GetNumberOfBranches() == 0) {
-      weight = Variable::FromString(x.GetBranchName() + ".ones");
-    }
+    weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, weight, cuts, true));
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});


### PR DESCRIPTION
Avoid crash when create a 'ones' var from multi-branch var, when GetBranchName() is not allowed.