### PR TITLE
Enable explicit histograms naming, allow choose between THF and THD histograms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,8 @@
 .idea/vcs.xml
 .idea/
 
+.vscode/
+.vscode/*
+
 *build*/
 install/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "cmake.configureSettings": {
-        "-DAnalysisTreeQA_BUNDLED_AT": "ON",
-
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cmake.configureSettings": {
+        "-DAnalysisTreeQA_BUNDLED_AT": "ON",
+
+    }
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ set(AnalysisTreeQA_BUNDLED_AT_GIT_SHALLOW ON CACHE BOOL "Use CMake GIT_SHALLOW o
 set(AnalysisTreeQA_BUNDLED_CUTS ON CACHE BOOL "Get and build AnalysisTreeCuts")
 set(AnalysisTreeQA_BUNDLED_CUTS_VERSION "v0.0.1" CACHE STRING "Bundled AnalysisTreeCuts version")
 
+option(USE_THD_HISTOGRAMS "Use THD histograms if ON, otherwise THF" OFF)
+if (USE_THD_HISTOGRAMS)
+    add_definitions(-DUseTHDHistograms)
+endif()
+
 # by default build optimized code
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RELEASE)

--- a/src/EntryConfig.cpp
+++ b/src/EntryConfig.cpp
@@ -39,28 +39,30 @@ struct write_struct : public Utils::Visitor<void> {
   std::string name_;
 };
 
-EntryConfig::EntryConfig(const Axis& axis, Variable& weight, Cuts* cuts, bool is_integral)
-  : name_(axis.GetName()),
+EntryConfig::EntryConfig(const Axis& axis, Variable& weight, const std::string& name, Cuts* cuts, bool is_integral)
+  : name_(name == "" ? axis.GetName() : name),
     type_(is_integral ? PlotType::kIntegral1D : PlotType::kHisto1D),
     axes_({axis}),
     var4weight_(weight),
     entry_cuts_(cuts) {
-  if (cuts)
-    name_ += "_" + cuts->GetName();
-  if (!var4weight_.GetName().empty() && var4weight_.GetFields().at(0).GetName() != "ones") {
-    name_ += "_weight_" + var4weight_.GetName();
-  }
-  if(is_integral){
-    name_ += "_integral";
+  if(name == "") {
+    if (cuts)
+      name_ += "_" + cuts->GetName();
+    if (!var4weight_.GetName().empty() && var4weight_.GetFields().at(0).GetName() != "ones") {
+      name_ += "_weight_" + var4weight_.GetName();
+    }
+    if(is_integral){
+      name_ += "_integral";
+    }
   }
   InitPlot();
 }
 
-EntryConfig::EntryConfig(const Axis& x, const Axis& y, Variable& weight, Cuts* cuts, bool is_profile) : type_(is_profile ? PlotType::kProfile : PlotType::kHisto2D),
+EntryConfig::EntryConfig(const Axis& x, const Axis& y, Variable& weight, const std::string& name, Cuts* cuts, bool is_profile) : type_(is_profile ? PlotType::kProfile : PlotType::kHisto2D),
                                                                                       axes_({x, y}),
                                                                                       var4weight_(weight),
                                                                                       entry_cuts_(cuts) {
-  Set2DName();
+  Set2DName(name);
   InitPlot();
 }
 
@@ -70,8 +72,6 @@ EntryConfig::EntryConfig(const Axis& x, Cuts* cuts_x, const Axis& y, Cuts* cuts_
   Set2DName();
   InitPlot();
 }
-
-
 
 TH1* EntryConfig::CreateHisto1D() const {
   auto* ret = new TH1FD(name_.c_str(), title_.c_str(),
@@ -137,17 +137,19 @@ void EntryConfig::InitPlot() {
   }
 }
 
-void EntryConfig::Set2DName() {
-  name_ = Form("%s_%s", axes_[0].GetName(), axes_[1].GetName());
-  if (entry_cuts_ != nullptr)
-    name_ += "_" + entry_cuts_->GetName();
+void EntryConfig::Set2DName(const std::string& name) {
+  name_ = name == "" ? Form("%s_%s", axes_[0].GetName(), axes_[1].GetName()) : name;
+  if(name == "") {
+    if (entry_cuts_ != nullptr)
+      name_ += "_" + entry_cuts_->GetName();
 
-  if (!var4weight_.GetName().empty() && var4weight_.GetFields().at(0).GetName() != "ones") {
-    name_ += "_weight_" + var4weight_.GetName();
-  }
+    if (!var4weight_.GetName().empty() && var4weight_.GetFields().at(0).GetName() != "ones") {
+      name_ += "_weight_" + var4weight_.GetName();
+    }
 
-  if (type_ == PlotType::kProfile) {
-    name_ += "_profile";
+    if (type_ == PlotType::kProfile) {
+      name_ += "_profile";
+    }
   }
 }
 

--- a/src/EntryConfig.cpp
+++ b/src/EntryConfig.cpp
@@ -5,6 +5,14 @@
 
 #include "EntryConfig.hpp"
 
+#ifdef UseTHDHistograms
+using TH1FD = TH1D;
+using TH2FD = TH2D;
+#else
+using TH1FD = TH1F;
+using TH2FD = TH2F;
+#endif
+
 namespace AnalysisTree {
 namespace QA {
 
@@ -66,7 +74,7 @@ EntryConfig::EntryConfig(const Axis& x, Cuts* cuts_x, const Axis& y, Cuts* cuts_
 
 
 TH1* EntryConfig::CreateHisto1D() const {
-  auto* ret = new TH1F(name_.c_str(), title_.c_str(),
+  auto* ret = new TH1FD(name_.c_str(), title_.c_str(),
                        axes_.at(0).GetNbins(), axes_.at(0).GetXmin(), axes_.at(0).GetXmax());
   ret->SetXTitle(axes_.at(0).GetTitle());
   ret->SetYTitle("Entries");
@@ -91,7 +99,7 @@ TProfile* EntryConfig::CreateProfile() const {
 
 TH2* EntryConfig::CreateHisto2D() const {
 
-  auto* ret = new TH2F(name_.c_str(), title_.c_str(),
+  auto* ret = new TH2FD(name_.c_str(), title_.c_str(),
                        axes_.at(0).GetNbins(), axes_.at(0).GetXmin(), axes_.at(0).GetXmax(),
                        axes_.at(1).GetNbins(), axes_.at(1).GetXmin(), axes_.at(1).GetXmax());
   ret->SetXTitle(axes_.at(0).GetTitle());

--- a/src/EntryConfig.hpp
+++ b/src/EntryConfig.hpp
@@ -46,8 +46,8 @@ class EntryConfig {
   };
 
   EntryConfig() = default;
-  explicit EntryConfig(const Axis& axis, [[maybe_unused]] Variable& weight, Cuts* cuts = nullptr, bool is_integral = false);
-  EntryConfig(const Axis& x, const Axis& y, Variable& weight, Cuts* cuts = nullptr, bool is_profile = false);
+  explicit EntryConfig(const Axis& axis, [[maybe_unused]] Variable& weight, const std::string& name, Cuts* cuts = nullptr, bool is_integral = false);
+  EntryConfig(const Axis& x, const Axis& y, Variable& weight, const std::string& name, Cuts* cuts = nullptr, bool is_profile = false);
   EntryConfig(const Axis& x, Cuts* cuts_x, const Axis& y, Cuts* cuts_y);
 
   EntryConfig(const EntryConfig&) = default;
@@ -94,7 +94,7 @@ class EntryConfig {
   ANALYSISTREE_ATTR_NODISCARD TH1* CreateHisto1D() const;
   ANALYSISTREE_ATTR_NODISCARD TH2* CreateHisto2D() const;
   ANALYSISTREE_ATTR_NODISCARD TProfile* CreateProfile() const;
-  void Set2DName();
+  void Set2DName(const std::string& name="");
 
   PlotPointer plot_;
   std::string name_;///< Name of the plot

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -20,36 +20,52 @@ class Task : public AnalysisTask {
   void Exec() override;
   void Finish() override;
 
-  size_t AddH1(const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+  size_t AddH1(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
-    entries_.emplace_back(EntryConfig(x, weight, cuts, false));
+    entries_.emplace_back(EntryConfig(x, weight, name, cuts, false));
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
     return entries_.size() - 1;
   }
 
-  size_t AddH2(const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+  size_t AddH1(const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+    return AddH1("", x, cuts, weight);
+  }
+
+  size_t AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
-    entries_.emplace_back(EntryConfig(x, y, weight, cuts));
+    entries_.emplace_back(EntryConfig(x, y, weight, name, cuts));
+    auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
+    entries_.back().SetVariablesId({ {var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)} });
+    return entries_.size() - 1;
+  }
+
+  size_t AddH2(const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+    return AddH2("", x, y, cuts, weight);
+  }
+
+  size_t AddProfile(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+    weight.IfEmptyVariableConvertToOnes(x);
+    entries_.emplace_back(EntryConfig(x, y, weight, name, cuts, true));
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({ {var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)} });
     return entries_.size() - 1;
   }
 
   size_t AddProfile(const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+    return AddProfile("", x, y, cuts, weight);
+  }
+
+  size_t AddIntegral(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
-    entries_.emplace_back(EntryConfig(x, y, weight, cuts, true));
+    entries_.emplace_back(EntryConfig(x, weight, name, cuts, true));
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
-    entries_.back().SetVariablesId({ {var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)} });
+    entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
     return entries_.size() - 1;
   }
 
   size_t AddIntegral(const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    weight.IfEmptyVariableConvertToOnes(x);
-    entries_.emplace_back(EntryConfig(x, weight, cuts, true));
-    auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
-    entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
-    return entries_.size() - 1;
+    return AddIntegral("", x, cuts, weight);
   }
 
   size_t AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x = nullptr, Cuts* cuts_y = nullptr) {


### PR DESCRIPTION
1. Explicit naming of histograms is possible when auto-naming becomes bulky and possibly redundant (e.g. cuts names are duplicated both in folder and histo name). The old signatures of `AddH1()`, `AddH2()` functions remain valid with the same effect of them, so old code will work properly. However when using this feature the correctness of histo naming is fully under user's responsibility.
2. Choose between THF and THD histograms is possible (in compile time via `-DUSE_THD_HISTOGRAMS=ON `cmake key). By default THF histograms will be built.