### PR TITLE
Enable multi-level directories creaton

### DIFF
--- a/src/BasicQA.hpp
+++ b/src/BasicQA.hpp
@@ -17,7 +17,6 @@ inline void AddEventHeaderQA(Task* task, const std::string& branch, Cuts* cuts =
   task->AddH2({"x_{vertex} (cm)", {branch, "vtx_x"}, {gNbins, -1, 1}}, {"y_{vertex} (cm)", {branch, "vtx_y"}, {gNbins, -1, 1}}, cuts);
 }
 
-
 inline void AddTrackQA(Task* task, const std::string& branch, Cuts* cuts = nullptr) {
 
   task->AddH1({"p_{x}, GeV/c", {branch, "px"}, {gNbins, -3, 3}}, cuts);

--- a/src/EntryConfig.cpp
+++ b/src/EntryConfig.cpp
@@ -186,7 +186,7 @@ std::string EntryConfig::GetDirectoryName() const {
   if (!var4weight_.GetName().empty() && var4weight_.GetFields().at(0).GetName() != "ones") {
     name += "_weight_" + var4weight_.GetName();
   }
-//  name.insert(0, "abcd/");
+  if(!toplevel_dir_name_.empty()) name.insert(0, toplevel_dir_name_ + "/");
   return name;
 }
 

--- a/src/EntryConfig.cpp
+++ b/src/EntryConfig.cpp
@@ -40,18 +40,18 @@ struct write_struct : public Utils::Visitor<void> {
 };
 
 EntryConfig::EntryConfig(const Axis& axis, Variable& weight, const std::string& name, Cuts* cuts, bool is_integral)
-  : name_(name == "" ? axis.GetName() : name),
-    type_(is_integral ? PlotType::kIntegral1D : PlotType::kHisto1D),
-    axes_({axis}),
-    var4weight_(weight),
-    entry_cuts_(cuts) {
-  if(name == "") {
+    : name_(name == "" ? axis.GetName() : name),
+      type_(is_integral ? PlotType::kIntegral1D : PlotType::kHisto1D),
+      axes_({axis}),
+      var4weight_(weight),
+      entry_cuts_(cuts) {
+  if (name == "") {
     if (cuts)
       name_ += "_" + cuts->GetName();
     if (!var4weight_.GetName().empty() && var4weight_.GetFields().at(0).GetName() != "ones") {
       name_ += "_weight_" + var4weight_.GetName();
     }
-    if(is_integral){
+    if (is_integral) {
       name_ += "_integral";
     }
   }
@@ -59,23 +59,23 @@ EntryConfig::EntryConfig(const Axis& axis, Variable& weight, const std::string& 
 }
 
 EntryConfig::EntryConfig(const Axis& x, const Axis& y, Variable& weight, const std::string& name, Cuts* cuts, bool is_profile) : type_(is_profile ? PlotType::kProfile : PlotType::kHisto2D),
-                                                                                      axes_({x, y}),
-                                                                                      var4weight_(weight),
-                                                                                      entry_cuts_(cuts) {
+                                                                                                                                 axes_({x, y}),
+                                                                                                                                 var4weight_(weight),
+                                                                                                                                 entry_cuts_(cuts) {
   Set2DName(name);
   InitPlot();
 }
 
 EntryConfig::EntryConfig(const Axis& x, Cuts* cuts_x, const Axis& y, Cuts* cuts_y) : type_(PlotType::kIntegral2D),
-                                                                                      axes_({x, y}),
-                                                                                      entry_cuts_(cuts_x) {
+                                                                                     axes_({x, y}),
+                                                                                     entry_cuts_(cuts_x) {
   Set2DName();
   InitPlot();
 }
 
 TH1* EntryConfig::CreateHisto1D() const {
   auto* ret = new TH1FD(name_.c_str(), title_.c_str(),
-                       axes_.at(0).GetNbins(), axes_.at(0).GetXmin(), axes_.at(0).GetXmax());
+                        axes_.at(0).GetNbins(), axes_.at(0).GetXmin(), axes_.at(0).GetXmax());
   ret->SetXTitle(axes_.at(0).GetTitle());
   ret->SetYTitle("Entries");
   return ret;
@@ -100,8 +100,8 @@ TProfile* EntryConfig::CreateProfile() const {
 TH2* EntryConfig::CreateHisto2D() const {
 
   auto* ret = new TH2FD(name_.c_str(), title_.c_str(),
-                       axes_.at(0).GetNbins(), axes_.at(0).GetXmin(), axes_.at(0).GetXmax(),
-                       axes_.at(1).GetNbins(), axes_.at(1).GetXmin(), axes_.at(1).GetXmax());
+                        axes_.at(0).GetNbins(), axes_.at(0).GetXmin(), axes_.at(0).GetXmax(),
+                        axes_.at(1).GetNbins(), axes_.at(1).GetXmin(), axes_.at(1).GetXmax());
   ret->SetXTitle(axes_.at(0).GetTitle());
   ret->SetYTitle(axes_.at(1).GetTitle());
   ret->SetZTitle("Entries");
@@ -139,7 +139,7 @@ void EntryConfig::InitPlot() {
 
 void EntryConfig::Set2DName(const std::string& name) {
   name_ = name == "" ? Form("%s_%s", axes_[0].GetName(), axes_[1].GetName()) : name;
-  if(name == "") {
+  if (name == "") {
     if (entry_cuts_ != nullptr)
       name_ += "_" + entry_cuts_->GetName();
 
@@ -186,7 +186,7 @@ std::string EntryConfig::GetDirectoryName() const {
   if (!var4weight_.GetName().empty() && var4weight_.GetFields().at(0).GetName() != "ones") {
     name += "_weight_" + var4weight_.GetName();
   }
-  if(!toplevel_dir_name_.empty()) name.insert(0, toplevel_dir_name_ + "/");
+  if (!toplevel_dir_name_.empty()) name.insert(0, toplevel_dir_name_ + "/");
   return name;
 }
 

--- a/src/EntryConfig.cpp
+++ b/src/EntryConfig.cpp
@@ -186,6 +186,7 @@ std::string EntryConfig::GetDirectoryName() const {
   if (!var4weight_.GetName().empty() && var4weight_.GetFields().at(0).GetName() != "ones") {
     name += "_weight_" + var4weight_.GetName();
   }
+//  name.insert(0, "abcd/");
   return name;
 }
 

--- a/src/EntryConfig.hpp
+++ b/src/EntryConfig.hpp
@@ -87,6 +87,8 @@ class EntryConfig {
 
   void SetOutDir(TDirectory* out_dir) { out_dir_ = out_dir; }
 
+  void SetTopLevelDirName(const std::string& name) { toplevel_dir_name_ = name; }
+
   PlotPointer GetPlot() { return plot_; }
 
  protected:
@@ -105,6 +107,7 @@ class EntryConfig {
   Variable var4weight_{};
   Cuts* entry_cuts_{nullptr};
   std::vector<std::pair<int, int>> vars_id_{};
+  std::string toplevel_dir_name_{""};
 
   TDirectory* out_dir_{nullptr};
   ClassDef(EntryConfig, 1);

--- a/src/EntryConfig.hpp
+++ b/src/EntryConfig.hpp
@@ -21,8 +21,8 @@ class Axis : public Variable, public TAxis {
   Axis() = default;
   Axis(const std::string& title, const Variable& var, const TAxis& a) : Variable(var), TAxis(a) {
     this->SetTitle(title.c_str());
-    if(this->GetFields().size() == 1 && this->GetFields().at(0).GetName() == "ones"){
-      this->lambda_ = [](const std::vector<double>& ){ return 1; };
+    if (this->GetFields().size() == 1 && this->GetFields().at(0).GetName() == "ones") {
+      this->lambda_ = [](const std::vector<double>&) { return 1; };
       this->name_ = "Ones";
     }
   }
@@ -96,7 +96,7 @@ class EntryConfig {
   ANALYSISTREE_ATTR_NODISCARD TH1* CreateHisto1D() const;
   ANALYSISTREE_ATTR_NODISCARD TH2* CreateHisto2D() const;
   ANALYSISTREE_ATTR_NODISCARD TProfile* CreateProfile() const;
-  void Set2DName(const std::string& name="");
+  void Set2DName(const std::string& name = "");
 
   PlotPointer plot_;
   std::string name_;///< Name of the plot

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -3,7 +3,7 @@
 namespace AnalysisTree {
 namespace QA {
 
-void Task::FillIntegral(EntryConfig& plot){
+void Task::FillIntegral(EntryConfig& plot) {
 
   double integral_x{0.};
   double integral_y{0.};
@@ -12,15 +12,14 @@ void Task::FillIntegral(EntryConfig& plot){
   for (const auto& var : this->GetValues(var_ids.at(0).first)) {
     integral_x += var[var_ids.at(0).second];
   }
-  if(plot.GetNdimentions() > 1) {
+  if (plot.GetNdimentions() > 1) {
     for (const auto& var : this->GetValues(var_ids.at(1).first)) {
       integral_y += var[var_ids.at(1).second];
     }
   }
-  if(plot.GetNdimentions() == 1) {
+  if (plot.GetNdimentions() == 1) {
     plot.Fill(integral_x);
-  }
-  else{
+  } else {
     plot.Fill(integral_x, integral_y);
   }
 }
@@ -31,7 +30,7 @@ void Task::Exec() {
 
   for (auto& plot : entries_) {
 
-    if(plot.GetType() == EntryConfig::PlotType::kIntegral1D || plot.GetType() == EntryConfig::PlotType::kIntegral2D){
+    if (plot.GetType() == EntryConfig::PlotType::kIntegral1D || plot.GetType() == EntryConfig::PlotType::kIntegral2D) {
       FillIntegral(plot);
       continue;
     }
@@ -41,16 +40,18 @@ void Task::Exec() {
     for (auto var : this->GetValues(var_ids.at(0).first)) {
       ++ivw;
       auto weight = weights.at(ivw);
-      if(std::fabs(weight) < 1e-6) continue;
+      if (std::fabs(weight) < 1e-6) continue;
       switch (plot.GetNdimentions()) {
         case 1: {
-          if(std::fabs(weight - 1) < 1e-4) plot.Fill(var[var_ids.at(0).second]);
-          else                                plot.Fill(var[var_ids.at(0).second], weight);
+          if (std::fabs(weight - 1) < 1e-4) plot.Fill(var[var_ids.at(0).second]);
+          else
+            plot.Fill(var[var_ids.at(0).second], weight);
           break;
         }
         case 2: {
-          if(std::fabs(weight - 1) < 1e-4) plot.Fill(var[var_ids.at(0).second], var[var_ids.at(1).second]);
-          else                                plot.Fill(var[var_ids.at(0).second], var[var_ids.at(1).second], weight);
+          if (std::fabs(weight - 1) < 1e-4) plot.Fill(var[var_ids.at(0).second], var[var_ids.at(1).second]);
+          else
+            plot.Fill(var[var_ids.at(0).second], var[var_ids.at(1).second], weight);
           break;
         }
       }
@@ -88,9 +89,10 @@ void Task::Init() {
 TDirectory* Task::MkMultiLevelDir(TFile* file, const std::string& name) const {
   auto vDirs = splitBySlash(name);
   TDirectory* result;
-  for(int iDir=0; iDir<vDirs.size(); iDir++) {
-    if(iDir==0) result = MkDirIfNotExists(file, vDirs.at(iDir));
-    else result = MkDirIfNotExists(result, vDirs.at(iDir));
+  for (int iDir = 0; iDir < vDirs.size(); iDir++) {
+    if (iDir == 0) result = MkDirIfNotExists(file, vDirs.at(iDir));
+    else
+      result = MkDirIfNotExists(result, vDirs.at(iDir));
   }
   return result;
 }
@@ -107,7 +109,6 @@ std::vector<std::string> Task::splitBySlash(const std::string& str) {
 
   return result;
 }
-
 
 }// namespace QA
 }// namespace AnalysisTree

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -78,19 +78,36 @@ void Task::Init() {
   out_file_ = new TFile(out_file_name_.c_str(), "recreate");
   for (const auto& dir : dirs) {
     out_file_->cd();
-    dir_map_.insert(std::make_pair(dir, out_file_->mkdir(dir.c_str())));
+    std::cout << "dir.c_str() = " << dir.c_str() << "\n";
+    dir_map_.insert(std::make_pair(dir, MkMultiLevelDir(out_file_, dir.c_str())));
   }
   for (auto& entry : entries_) {
     entry.SetOutDir(dir_map_.find(entry.GetDirectoryName())->second);
   }
 }
 
-//size_t Task::AddAnalysisEntry(const Axis& a, Cuts* cuts, bool is_integral){
-//  entries_.emplace_back(EntryConfig(a, cuts, is_integral));
-//  auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts()));
-//  entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
-//  return entries_.size() - 1;
-//}
+TDirectory* Task::MkMultiLevelDir(TFile* file, std::string name) const {
+  auto vDirs = splitBySlash(name);
+  TDirectory* result;
+  for(int iDir=0; iDir<vDirs.size(); iDir++) {
+    if(iDir==0) result = MkDirIfNotExists(file, vDirs.at(iDir).c_str());
+    else result = MkDirIfNotExists(result, vDirs.at(iDir).c_str());
+  }
+  return result;
+}
+
+std::vector<std::string> Task::splitBySlash(const std::string& str) {
+  std::vector<std::string> result;
+  std::stringstream ss(str);
+  std::string item;
+
+  // Split the string by slashes
+  while (std::getline(ss, item, '/')) {
+    result.push_back(item);
+  }
+
+  return result;
+}
 
 
 }// namespace QA

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -78,20 +78,19 @@ void Task::Init() {
   out_file_ = new TFile(out_file_name_.c_str(), "recreate");
   for (const auto& dir : dirs) {
     out_file_->cd();
-    std::cout << "dir.c_str() = " << dir.c_str() << "\n";
-    dir_map_.insert(std::make_pair(dir, MkMultiLevelDir(out_file_, dir.c_str())));
+    dir_map_.insert(std::make_pair(dir, MkMultiLevelDir(out_file_, dir)));
   }
   for (auto& entry : entries_) {
     entry.SetOutDir(dir_map_.find(entry.GetDirectoryName())->second);
   }
 }
 
-TDirectory* Task::MkMultiLevelDir(TFile* file, std::string name) const {
+TDirectory* Task::MkMultiLevelDir(TFile* file, const std::string& name) const {
   auto vDirs = splitBySlash(name);
   TDirectory* result;
   for(int iDir=0; iDir<vDirs.size(); iDir++) {
-    if(iDir==0) result = MkDirIfNotExists(file, vDirs.at(iDir).c_str());
-    else result = MkDirIfNotExists(result, vDirs.at(iDir).c_str());
+    if(iDir==0) result = MkDirIfNotExists(file, vDirs.at(iDir));
+    else result = MkDirIfNotExists(result, vDirs.at(iDir));
   }
   return result;
 }

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -81,7 +81,16 @@ class Task : public AnalysisTask {
 
  private:
   void FillIntegral(EntryConfig& plot);
-//  size_t AddAnalysisEntry(const Axis& a, Cuts* cuts, bool is_integral);
+  TDirectory* MkMultiLevelDir(TFile* file, std::string name) const;
+
+  template <typename T>
+  TDirectory* MkDirIfNotExists(T* fod, std::string name) const {
+    TDirectory* result = fod->GetDirectory(name.c_str());
+    if(result == nullptr) result = fod->mkdir(name.c_str());
+    return result;
+  }
+
+  static std::vector<std::string> splitBySlash(const std::string& str);
 
   std::vector<EntryConfig> entries_{};
   std::map<std::string, TDirectory*> dir_map_{};

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -38,7 +38,7 @@ class Task : public AnalysisTask {
     entries_.emplace_back(EntryConfig(x, y, weight, name, cuts));
     entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
-    entries_.back().SetVariablesId({ {var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)} });
+    entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)}});
     return entries_.size() - 1;
   }
 
@@ -51,7 +51,7 @@ class Task : public AnalysisTask {
     entries_.emplace_back(EntryConfig(x, y, weight, name, cuts, true));
     entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
-    entries_.back().SetVariablesId({ {var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)} });
+    entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)}});
     return entries_.size() - 1;
   }
 
@@ -77,7 +77,7 @@ class Task : public AnalysisTask {
     entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     auto var_id_x = AddEntry(AnalysisEntry({entries_.back().GetVariables()[0]}, cuts_x));
     auto var_id_y = AddEntry(AnalysisEntry({entries_.back().GetVariables()[1]}, cuts_y));
-    entries_.back().SetVariablesId({ {var_id_x.first, var_id_x.second.at(0)}, {var_id_y.first, var_id_y.second.at(0)} });
+    entries_.back().SetVariablesId({{var_id_x.first, var_id_x.second.at(0)}, {var_id_y.first, var_id_y.second.at(0)}});
     return entries_.size() - 1;
   }
 
@@ -90,10 +90,10 @@ class Task : public AnalysisTask {
   void FillIntegral(EntryConfig& plot);
   TDirectory* MkMultiLevelDir(TFile* file, const std::string& name) const;
 
-  template <typename T>
+  template<typename T>
   TDirectory* MkDirIfNotExists(T* fod, std::string name) const {
     TDirectory* result = fod->GetDirectory(name.c_str());
-    if(result == nullptr) result = fod->mkdir(name.c_str());
+    if (result == nullptr) result = fod->mkdir(name.c_str());
     return result;
   }
 

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -23,6 +23,7 @@ class Task : public AnalysisTask {
   size_t AddH1(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, weight, name, cuts, false));
+    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
     return entries_.size() - 1;
@@ -35,6 +36,7 @@ class Task : public AnalysisTask {
   size_t AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, y, weight, name, cuts));
+    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({ {var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)} });
     return entries_.size() - 1;
@@ -47,6 +49,7 @@ class Task : public AnalysisTask {
   size_t AddProfile(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, y, weight, name, cuts, true));
+    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({ {var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)} });
     return entries_.size() - 1;
@@ -59,6 +62,7 @@ class Task : public AnalysisTask {
   size_t AddIntegral(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, weight, name, cuts, true));
+    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
     return entries_.size() - 1;
@@ -70,6 +74,7 @@ class Task : public AnalysisTask {
 
   size_t AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x = nullptr, Cuts* cuts_y = nullptr) {
     entries_.emplace_back(EntryConfig(x, cuts_x, y, cuts_y));
+    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     auto var_id_x = AddEntry(AnalysisEntry({entries_.back().GetVariables()[0]}, cuts_x));
     auto var_id_y = AddEntry(AnalysisEntry({entries_.back().GetVariables()[1]}, cuts_y));
     entries_.back().SetVariablesId({ {var_id_x.first, var_id_x.second.at(0)}, {var_id_y.first, var_id_y.second.at(0)} });
@@ -78,10 +83,12 @@ class Task : public AnalysisTask {
 
   std::vector<EntryConfig>& Entries() { return entries_; }
   void SetOutputFileName(std::string name) { out_file_name_ = std::move(name); }
+  void SetTopLevelDirName(const std::string& name) { toplevel_dir_name_ = name; }
+  void ResetTopLevelDirName() { toplevel_dir_name_ = ""; }
 
  private:
   void FillIntegral(EntryConfig& plot);
-  TDirectory* MkMultiLevelDir(TFile* file, std::string name) const;
+  TDirectory* MkMultiLevelDir(TFile* file, const std::string& name) const;
 
   template <typename T>
   TDirectory* MkDirIfNotExists(T* fod, std::string name) const {
@@ -95,6 +102,7 @@ class Task : public AnalysisTask {
   std::vector<EntryConfig> entries_{};
   std::map<std::string, TDirectory*> dir_map_{};
   std::string out_file_name_{"QA.root"};
+  std::string toplevel_dir_name_{""};
   TFile* out_file_{nullptr};
 
   ClassDefOverride(Task, 1);


### PR DESCRIPTION
Multi-level `TDirector`ies in the output file can be produced - useful to keep in order histograms related to different tasks, selections and other conditions. To use this option call function `QA::Task::SetTopLevelDirName()` before `AddH1()`, `AddH2()`, etc.