### PR TITLE
Assign directory to each ATQA::Plot - avoid "duplication name" warning

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,8 +13,13 @@ if(PROJECT_LINK_DIRECTORIES)
     link_directories(${PROJECT_LINK_DIRECTORIES})
 endif()
 
-add_executable(example example.cpp)
-add_dependencies(example AnalysisTreeQA)
-target_link_libraries(example ${ROOT_LIBRARIES} AnalysisTreeQA AnalysisTreeBase AnalysisTreeInfra)
+set(EXECUTABLES example
+                )
 
-install (TARGETS example RUNTIME DESTINATION bin)
+foreach(EXE ${EXECUTABLES})
+    add_executable(${EXE} ${EXE}.cpp)
+    add_dependencies(${EXE} AnalysisTreeQA)
+    target_link_libraries(${EXE} ${ROOT_LIBRARIES} AnalysisTreeQA AnalysisTreeBase AnalysisTreeInfra)
+    install (TARGETS ${EXE} RUNTIME DESTINATION bin)
+    install (FILES ${EXE}.cpp DESTINATION share)
+endforeach()

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -64,7 +64,7 @@ void example(const std::string& filelist){
   //Integral plot 1D
   SimpleCut vtx_chi2_track_cut = RangeCut({"VtxTracks.vtx_chi2"}, 0, 3);
   SimpleCut nhits_cut = RangeCut({"VtxTracks.nhits"}, 4, 100);
-  SimpleCut chi2_cut({"VtxTracks.chi2", "VtxTracks.ndf"}, [](std::vector<double> par){ return par[0]/par[1] < 10; });
+  SimpleCut chi2_cut((std::vector<std::string>){"VtxTracks.chi2", "VtxTracks.ndf"}, [](std::vector<double> par){ return par[0]/par[1] < 10; });
   SimpleCut eta_cut = RangeCut({"VtxTracks.eta"}, 0, 3);
   Cuts* vertex_tracks_cuts = new Cuts("GoodCentralityTracks", {vtx_chi2_track_cut, nhits_cut, chi2_cut, eta_cut});
   task->AddIntegral({"Multiplicity", Variable::FromString("VtxTracks.ones"), {1000, 0, 1000}}, vertex_tracks_cuts);

--- a/src/EntryConfig.cpp
+++ b/src/EntryConfig.cpp
@@ -13,8 +13,7 @@ using TH1FD = TH1F;
 using TH2FD = TH2F;
 #endif
 
-namespace AnalysisTree {
-namespace QA {
+namespace AnalysisTree::QA {
 
 struct fill2_struct : public Utils::Visitor<void> {
   fill2_struct(double val1, double val2) : val1_(val1), val2_(val2) {}
@@ -131,8 +130,8 @@ void EntryConfig::InitPlot() {
 }
 
 void EntryConfig::Set2DName(const std::string& name) {
-  name_ = name == "" ? Form("%s_%s", axes_[0].GetName(), axes_[1].GetName()) : name;
-  if (name == "") {
+  name_ = name.empty() ? Form("%s_%s", axes_[0].GetName(), axes_[1].GetName()) : name;
+  if (name.empty()) {
     if (entry_cuts_ != nullptr)
       name_ += "_" + entry_cuts_->GetName();
 
@@ -176,5 +175,4 @@ std::string EntryConfig::GetDirectoryName() const {
   return name;
 }
 
-}// namespace QA
-}// namespace AnalysisTree
+} // namespace AnalysisTree::QA

--- a/src/EntryConfig.cpp
+++ b/src/EntryConfig.cpp
@@ -32,13 +32,6 @@ struct fill3_struct : public Utils::Visitor<void> {
   double val1_, val2_, val3_;
 };
 
-struct write_struct : public Utils::Visitor<void> {
-  explicit write_struct(std::string n) : name_(std::move(n)) {}
-  template<class PlotType>
-  void operator()(PlotType* p) const { p->Write(name_.c_str()); }
-  std::string name_;
-};
-
 EntryConfig::EntryConfig(const Axis& axis, Variable& weight, const std::string& name, Cuts* cuts, bool is_integral)
     : name_(name == "" ? axis.GetName() : name),
       type_(is_integral ? PlotType::kIntegral1D : PlotType::kHisto1D),

--- a/src/EntryConfig.cpp
+++ b/src/EntryConfig.cpp
@@ -161,12 +161,6 @@ void EntryConfig::Fill(double value1, double value2, double value3) {
   ANALYSISTREE_UTILS_VISIT(fill3_struct(value1, value2, value3), plot_);
 }
 
-void EntryConfig::Write() const {
-  assert(out_dir_);
-  out_dir_->cd();
-  ANALYSISTREE_UTILS_VISIT(write_struct(name_), plot_);
-}
-
 void EntryConfig::Fill(double value) { ANALYSISTREE_UTILS_GET<TH1*>(plot_)->Fill(value); }
 
 std::string EntryConfig::GetDirectoryName() const {
@@ -186,7 +180,6 @@ std::string EntryConfig::GetDirectoryName() const {
   if (!var4weight_.GetName().empty() && var4weight_.GetFields().at(0).GetName() != "ones") {
     name += "_weight_" + var4weight_.GetName();
   }
-  if (!toplevel_dir_name_.empty()) name.insert(0, toplevel_dir_name_ + "/");
   return name;
 }
 

--- a/src/EntryConfig.hpp
+++ b/src/EntryConfig.hpp
@@ -12,8 +12,7 @@
 #include "AnalysisTree/Cuts.hpp"
 #include "AnalysisTree/Utils.hpp"
 
-namespace AnalysisTree {
-namespace QA {
+namespace AnalysisTree::QA {
 
 class Axis : public Variable, public TAxis {
  public:
@@ -59,10 +58,7 @@ class EntryConfig {
   void Fill(double value1, double value2);
   void Fill(double value1, double value2, double value3);
 
-  ANALYSISTREE_ATTR_NODISCARD const std::vector<Axis>& GetAxes() const { return axes_; }
-  std::vector<Axis>& Axes() { return axes_; }
-
-  ANALYSISTREE_ATTR_NODISCARD unsigned int GetNdimentions() const { return axes_.size(); }
+  ANALYSISTREE_ATTR_NODISCARD unsigned int GetNdimensions() const { return axes_.size(); }
   ANALYSISTREE_ATTR_NODISCARD Cuts* GetEntryCuts() const { return entry_cuts_; }
   ANALYSISTREE_ATTR_NODISCARD PlotType GetType() const { return type_; }
 
@@ -107,6 +103,5 @@ class EntryConfig {
   ClassDef(EntryConfig, 1);
 };
 
-}// namespace QA
-}// namespace AnalysisTree
+}// namespace AnalysisTree::QA
 #endif//ANALYSISTREE_QA_ENTRYCONFIG_H

--- a/src/EntryConfig.hpp
+++ b/src/EntryConfig.hpp
@@ -5,13 +5,12 @@
 #include <vector>
 
 #include <TAxis.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TProfile.h>
 
 #include "AnalysisTree/Cuts.hpp"
 #include "AnalysisTree/Utils.hpp"
-
-class TH1;
-class TH2;
-class TProfile;
 
 namespace AnalysisTree {
 namespace QA {
@@ -90,6 +89,8 @@ class EntryConfig {
   void SetTopLevelDirName(const std::string& name) { toplevel_dir_name_ = name; }
 
   PlotPointer GetPlot() { return plot_; }
+
+  const std::string& GetName() const { return name_; }
 
  protected:
   void InitPlot();

--- a/src/EntryConfig.hpp
+++ b/src/EntryConfig.hpp
@@ -58,7 +58,6 @@ class EntryConfig {
   void Fill(double value);
   void Fill(double value1, double value2);
   void Fill(double value1, double value2, double value3);
-  void Write() const;
 
   ANALYSISTREE_ATTR_NODISCARD const std::vector<Axis>& GetAxes() const { return axes_; }
   std::vector<Axis>& Axes() { return axes_; }
@@ -84,10 +83,6 @@ class EntryConfig {
 
   ANALYSISTREE_ATTR_NODISCARD std::string GetDirectoryName() const;
 
-  void SetOutDir(TDirectory* out_dir) { out_dir_ = out_dir; }
-
-  void SetTopLevelDirName(const std::string& name) { toplevel_dir_name_ = name; }
-
   PlotPointer GetPlot() { return plot_; }
 
   const std::string& GetName() const { return name_; }
@@ -108,9 +103,7 @@ class EntryConfig {
   Variable var4weight_{};
   Cuts* entry_cuts_{nullptr};
   std::vector<std::pair<int, int>> vars_id_{};
-  std::string toplevel_dir_name_{""};
 
-  TDirectory* out_dir_{nullptr};
   ClassDef(EntryConfig, 1);
 };
 

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -3,6 +3,82 @@
 namespace AnalysisTree {
 namespace QA {
 
+size_t Task::AddH1(const std::string& name, const Axis& x, Cuts* cuts, Variable weight) {
+  CreateOutputFileIfNotYet();
+  weight.IfEmptyVariableConvertToOnes(x);
+  entries_.emplace_back(EntryConfig(x, weight, name, cuts, false));
+  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+  ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
+  auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
+  entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
+  return entries_.size() - 1;
+}
+
+size_t Task::AddH1(const Axis& x, Cuts* cuts, Variable weight) {
+  return AddH1("", x, cuts, weight);
+}
+
+size_t Task::AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts, Variable weight) {
+  CreateOutputFileIfNotYet();
+  weight.IfEmptyVariableConvertToOnes(x);
+  entries_.emplace_back(EntryConfig(x, y, weight, name, cuts));
+  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+  ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
+  auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
+  entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)}});
+  return entries_.size() - 1;
+}
+
+size_t Task::AddH2(const Axis& x, const Axis& y, Cuts* cuts, Variable weight) {
+  return AddH2("", x, y, cuts, weight);
+}
+
+size_t Task::AddProfile(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts, Variable weight) {
+  CreateOutputFileIfNotYet();
+  weight.IfEmptyVariableConvertToOnes(x);
+  entries_.emplace_back(EntryConfig(x, y, weight, name, cuts, true));
+  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+  ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
+  auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
+  entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)}});
+  return entries_.size() - 1;
+}
+
+size_t Task::AddProfile(const Axis& x, const Axis& y, Cuts* cuts, Variable weight) {
+  return AddProfile("", x, y, cuts, weight);
+}
+
+size_t Task::AddIntegral(const std::string& name, const Axis& x, Cuts* cuts, Variable weight) {
+  CreateOutputFileIfNotYet();
+  weight.IfEmptyVariableConvertToOnes(x);
+  entries_.emplace_back(EntryConfig(x, weight, name, cuts, true));
+  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+  ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
+  auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
+  entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
+  return entries_.size() - 1;
+}
+
+size_t Task::AddIntegral(const Axis& x, Cuts* cuts, Variable weight) {
+  return AddIntegral("", x, cuts, weight);
+}
+
+size_t Task::AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x, Cuts* cuts_y) {
+  CreateOutputFileIfNotYet();
+  entries_.emplace_back(EntryConfig(x, cuts_x, y, cuts_y));
+  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+  ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
+  auto var_id_x = AddEntry(AnalysisEntry({entries_.back().GetVariables()[0]}, cuts_x));
+  auto var_id_y = AddEntry(AnalysisEntry({entries_.back().GetVariables()[1]}, cuts_y));
+  entries_.back().SetVariablesId({{var_id_x.first, var_id_x.second.at(0)}, {var_id_y.first, var_id_y.second.at(0)}});
+  return entries_.size() - 1;
+}
+
 void Task::FillIntegral(EntryConfig& plot) {
 
   double integral_x{0.};

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -61,10 +61,6 @@ void Task::Exec() {
 }
 
 void Task::Finish() {
-  out_file_->cd();
-//  for (auto& plot : entries_) {
-//    plot.Write();
-//  }
   out_file_->Write();
   out_file_->Close();
 }
@@ -74,20 +70,22 @@ void Task::Init() {
   AnalysisTask::Init();
   std::set<std::string> dirs{};
 
-//  for (auto& entry : entries_) {
-//    dirs.insert(entry.GetDirectoryName());
-//  }
-//  out_file_ = new TFile(out_file_name_.c_str(), "recreate");
-//  for (const auto& dir : dirs) {
-//    out_file_->cd();
-//    dir_map_.insert(std::make_pair(dir, MkMultiLevelDir(out_file_, dir)));
-//  }
-//  for (auto& entry : entries_) {
-//    entry.SetOutDir(dir_map_.find(entry.GetDirectoryName())->second);
-//  }
 }
 
 TDirectory* Task::MkMultiLevelDir(TFile* file, const std::string& name) const {
+  auto splitBySlash = [] (const std::string& str) {
+    std::vector<std::string> result;
+    std::stringstream ss(str);
+    std::string item;
+
+    // Split the string by slashes
+    while (std::getline(ss, item, '/')) {
+      result.push_back(item);
+    }
+
+    return result;
+  };
+
   auto vDirs = splitBySlash(name);
   TDirectory* result;
   for (int iDir = 0; iDir < vDirs.size(); iDir++) {
@@ -98,17 +96,8 @@ TDirectory* Task::MkMultiLevelDir(TFile* file, const std::string& name) const {
   return result;
 }
 
-std::vector<std::string> Task::splitBySlash(const std::string& str) {
-  std::vector<std::string> result;
-  std::stringstream ss(str);
-  std::string item;
-
-  // Split the string by slashes
-  while (std::getline(ss, item, '/')) {
-    result.push_back(item);
-  }
-
-  return result;
+void Task::CreateOutputFileIfNotYet() {
+  if (out_file_ == nullptr) out_file_ = new TFile(out_file_name_.c_str(), "recreate");
 }
 
 }// namespace QA

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -62,9 +62,10 @@ void Task::Exec() {
 
 void Task::Finish() {
   out_file_->cd();
-  for (auto& plot : entries_) {
-    plot.Write();
-  }
+//  for (auto& plot : entries_) {
+//    plot.Write();
+//  }
+  out_file_->Write();
   out_file_->Close();
 }
 
@@ -73,17 +74,17 @@ void Task::Init() {
   AnalysisTask::Init();
   std::set<std::string> dirs{};
 
-  for (auto& entry : entries_) {
-    dirs.insert(entry.GetDirectoryName());
-  }
-  out_file_ = new TFile(out_file_name_.c_str(), "recreate");
-  for (const auto& dir : dirs) {
-    out_file_->cd();
-    dir_map_.insert(std::make_pair(dir, MkMultiLevelDir(out_file_, dir)));
-  }
-  for (auto& entry : entries_) {
-    entry.SetOutDir(dir_map_.find(entry.GetDirectoryName())->second);
-  }
+//  for (auto& entry : entries_) {
+//    dirs.insert(entry.GetDirectoryName());
+//  }
+//  out_file_ = new TFile(out_file_name_.c_str(), "recreate");
+//  for (const auto& dir : dirs) {
+//    out_file_->cd();
+//    dir_map_.insert(std::make_pair(dir, MkMultiLevelDir(out_file_, dir)));
+//  }
+//  for (auto& entry : entries_) {
+//    entry.SetOutDir(dir_map_.find(entry.GetDirectoryName())->second);
+//  }
 }
 
 TDirectory* Task::MkMultiLevelDir(TFile* file, const std::string& name) const {

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -12,6 +12,20 @@
 namespace AnalysisTree {
 namespace QA {
 
+struct setdirectory_struct : Utils::Visitor<void> {
+  explicit setdirectory_struct(TDirectory* dir) : dir_(dir) {}
+  template<class PlotType>
+  void operator()(PlotType* p) const { p->SetDirectory(dir_); }
+  TDirectory* dir_;
+};
+
+struct setname_struct : Utils::Visitor<void> {
+  explicit setname_struct(const std::string& name) : name_(name) {}
+  template<class PlotType>
+  void operator()(PlotType* p) const { p->SetName(name_.c_str()); }
+  std::string name_;
+};
+
 class Task : public AnalysisTask {
  public:
   Task() = default;
@@ -23,7 +37,10 @@ class Task : public AnalysisTask {
   size_t AddH1(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, weight, name, cuts, false));
-    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
     return entries_.size() - 1;
@@ -36,7 +53,10 @@ class Task : public AnalysisTask {
   size_t AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, y, weight, name, cuts));
-    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)}});
     return entries_.size() - 1;
@@ -49,7 +69,10 @@ class Task : public AnalysisTask {
   size_t AddProfile(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, y, weight, name, cuts, true));
-    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)}});
     return entries_.size() - 1;
@@ -62,7 +85,10 @@ class Task : public AnalysisTask {
   size_t AddIntegral(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, weight, name, cuts, true));
-    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
     auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
     entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
     return entries_.size() - 1;
@@ -74,7 +100,10 @@ class Task : public AnalysisTask {
 
   size_t AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x = nullptr, Cuts* cuts_y = nullptr) {
     entries_.emplace_back(EntryConfig(x, cuts_x, y, cuts_y));
-    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
+    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
+    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
     auto var_id_x = AddEntry(AnalysisEntry({entries_.back().GetVariables()[0]}, cuts_x));
     auto var_id_y = AddEntry(AnalysisEntry({entries_.back().GetVariables()[1]}, cuts_y));
     entries_.back().SetVariablesId({{var_id_x.first, var_id_x.second.at(0)}, {var_id_y.first, var_id_y.second.at(0)}});
@@ -82,7 +111,10 @@ class Task : public AnalysisTask {
   }
 
   std::vector<EntryConfig>& Entries() { return entries_; }
-  void SetOutputFileName(std::string name) { out_file_name_ = std::move(name); }
+  void SetOutputFileName(std::string name) { // TODO fix function name or mv new TFile smw else
+    out_file_name_ = std::move(name);
+    out_file_ = new TFile(out_file_name_.c_str(), "recreate");
+  }
   void SetTopLevelDirName(const std::string& name) { toplevel_dir_name_ = name; }
   void ResetTopLevelDirName() { toplevel_dir_name_ = ""; }
 
@@ -92,6 +124,7 @@ class Task : public AnalysisTask {
 
   template<typename T>
   TDirectory* MkDirIfNotExists(T* fod, std::string name) const {
+    if(fod == nullptr) throw std::runtime_error("Task::MkDirIfNotExists(): file or directory ptr is null");
     TDirectory* result = fod->GetDirectory(name.c_str());
     if (result == nullptr) result = fod->mkdir(name.c_str());
     return result;

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -34,81 +34,23 @@ class Task : public AnalysisTask {
   void Exec() override;
   void Finish() override;
 
-  size_t AddH1(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    CreateOutputFileIfNotYet();
-    weight.IfEmptyVariableConvertToOnes(x);
-    entries_.emplace_back(EntryConfig(x, weight, name, cuts, false));
-    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
-    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
-    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
-    auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
-    entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
-    return entries_.size() - 1;
-  }
+  size_t AddH1(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{});
 
-  size_t AddH1(const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    return AddH1("", x, cuts, weight);
-  }
+  size_t AddH1(const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{});
 
-  size_t AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    CreateOutputFileIfNotYet();
-    weight.IfEmptyVariableConvertToOnes(x);
-    entries_.emplace_back(EntryConfig(x, y, weight, name, cuts));
-    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
-    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
-    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
-    auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
-    entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)}});
-    return entries_.size() - 1;
-  }
+  size_t AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{});
 
-  size_t AddH2(const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    return AddH2("", x, y, cuts, weight);
-  }
+  size_t AddH2(const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{});
 
-  size_t AddProfile(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    CreateOutputFileIfNotYet();
-    weight.IfEmptyVariableConvertToOnes(x);
-    entries_.emplace_back(EntryConfig(x, y, weight, name, cuts, true));
-    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
-    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
-    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
-    auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
-    entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}, {var_id.first, var_id.second.at(1)}});
-    return entries_.size() - 1;
-  }
+  size_t AddProfile(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{});
 
-  size_t AddProfile(const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    return AddProfile("", x, y, cuts, weight);
-  }
+  size_t AddProfile(const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{});
 
-  size_t AddIntegral(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    CreateOutputFileIfNotYet();
-    weight.IfEmptyVariableConvertToOnes(x);
-    entries_.emplace_back(EntryConfig(x, weight, name, cuts, true));
-    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
-    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
-    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
-    auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
-    entries_.back().SetVariablesId({{var_id.first, var_id.second.at(0)}});
-    return entries_.size() - 1;
-  }
+  size_t AddIntegral(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{});
 
-  size_t AddIntegral(const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
-    return AddIntegral("", x, cuts, weight);
-  }
+  size_t AddIntegral(const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{});
 
-  size_t AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x = nullptr, Cuts* cuts_y = nullptr) {
-    CreateOutputFileIfNotYet();
-    entries_.emplace_back(EntryConfig(x, cuts_x, y, cuts_y));
-    TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
-    ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
-    ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
-    auto var_id_x = AddEntry(AnalysisEntry({entries_.back().GetVariables()[0]}, cuts_x));
-    auto var_id_y = AddEntry(AnalysisEntry({entries_.back().GetVariables()[1]}, cuts_y));
-    entries_.back().SetVariablesId({{var_id_x.first, var_id_x.second.at(0)}, {var_id_y.first, var_id_y.second.at(0)}});
-    return entries_.size() - 1;
-  }
+  size_t AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x = nullptr, Cuts* cuts_y = nullptr);
 
   std::vector<EntryConfig>& Entries() { return entries_; }
   void SetOutputFileName(std::string name) { out_file_name_ = std::move(name); }

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -30,7 +30,6 @@ class Task : public AnalysisTask {
  public:
   Task() = default;
 
-  void Init() override;
   void Exec() override;
   void Finish() override;
 

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -35,9 +35,9 @@ class Task : public AnalysisTask {
   void Finish() override;
 
   size_t AddH1(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+    CreateOutputFileIfNotYet();
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, weight, name, cuts, false));
-//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
     ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
     ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -51,9 +51,9 @@ class Task : public AnalysisTask {
   }
 
   size_t AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+    CreateOutputFileIfNotYet();
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, y, weight, name, cuts));
-//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
     ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
     ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -67,9 +67,9 @@ class Task : public AnalysisTask {
   }
 
   size_t AddProfile(const std::string& name, const Axis& x, const Axis& y, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+    CreateOutputFileIfNotYet();
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, y, weight, name, cuts, true));
-//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
     ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
     ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -83,9 +83,9 @@ class Task : public AnalysisTask {
   }
 
   size_t AddIntegral(const std::string& name, const Axis& x, Cuts* cuts = nullptr, Variable weight = Variable{}) {
+    CreateOutputFileIfNotYet();
     weight.IfEmptyVariableConvertToOnes(x);
     entries_.emplace_back(EntryConfig(x, weight, name, cuts, true));
-//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
     ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
     ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -99,8 +99,8 @@ class Task : public AnalysisTask {
   }
 
   size_t AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x = nullptr, Cuts* cuts_y = nullptr) {
+    CreateOutputFileIfNotYet();
     entries_.emplace_back(EntryConfig(x, cuts_x, y, cuts_y));
-//    entries_.back().SetTopLevelDirName(toplevel_dir_name_);
     TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
     ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
     ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -111,10 +111,7 @@ class Task : public AnalysisTask {
   }
 
   std::vector<EntryConfig>& Entries() { return entries_; }
-  void SetOutputFileName(std::string name) { // TODO fix function name or mv new TFile smw else
-    out_file_name_ = std::move(name);
-    out_file_ = new TFile(out_file_name_.c_str(), "recreate");
-  }
+  void SetOutputFileName(std::string name) { out_file_name_ = std::move(name); }
   void SetTopLevelDirName(const std::string& name) { toplevel_dir_name_ = name; }
   void ResetTopLevelDirName() { toplevel_dir_name_ = ""; }
 
@@ -130,7 +127,7 @@ class Task : public AnalysisTask {
     return result;
   }
 
-  static std::vector<std::string> splitBySlash(const std::string& str);
+  void CreateOutputFileIfNotYet();
 
   std::vector<EntryConfig> entries_{};
   std::map<std::string, TDirectory*> dir_map_{};


### PR DESCRIPTION
**Major change:**
Before all the plots (`TH1`, `TH2`, `TProfile`) were created, filled then one created a proper `TDirectory`, moved to it and `Write()` a Plot. In this case if two objects have the same name (string), the Root produced `Warning in <TROOT::Append>: Replacing existing TH1: myHistogramName (Potential memory leak)`.
Now it is solved due to `SetDirectory()` to each plot right after its definition. And then instead of `Write()` each plot just the output `TFile` is `Write()`.
**Minor changes:**
1. Executable codes are propagated into `install` directory for documenting of the run.
2. Cosmetics of the code done: moved extensive writing of function implementations from `Task.hpp` to `Task.cpp`; addressed clang-tidy suggestions.