### PR TITLE
Fix CI build error at centos7

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,17 +16,21 @@ permissions:
 
 jobs:
   build_centos7:
-    container: kreisl/rootcpp17
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Configure CMake
-        run: source /opt/rh/devtoolset-8/enable && cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAnalysisTreeQA_BUILD_TESTS=ON -DAnalysisTreeQA_BUNDLED_AT=ON
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-      - name: Test
-        run: cd ${{github.workspace}}/build && ctest -C ${{env.BUILD_TYPE}}
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build & test in CentOS 7
+        uses: docker://kreisl/rootcpp17
+        with:
+          entrypoint: /bin/bash
+          args: -lc "
+            source /opt/rh/devtoolset-8/enable &&
+            cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAnalysisTreeQA_BUILD_TESTS=ON -DAnalysisTreeQA_BUNDLED_AT=ON . &&
+            cmake --build build &&
+            cd build && ctest -C ${{env.BUILD_TYPE}}"
         
   build_fedora35:
     container: rootproject/root:6.24.06-fedora35


### PR DESCRIPTION
Since July 2024 the CI test at centos 7 machine crashed at the build stage with the following error message:
```
Post job cleanup.
/usr/bin/docker exec  351da720762074b5803bf4c1c2a4088e926cadb4adfa93b20239125a6b80dbe2 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```
This PR fixes this issue.