### PR TITLE
Enhance user-friendness and clean code

### DIFF
--- a/examples/get_test_input.sh
+++ b/examples/get_test_input.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-mkdir -p data/analysistree
-rsync -av /u/klochkov/temp/temp/atree/1.analysistree.root data/analysistree/
-
-ls -d data/analysistree/ > data/filelist.txt

--- a/examples/rootlogon.C
+++ b/examples/rootlogon.C
@@ -1,5 +1,0 @@
-{
-  gSystem->Load("libAnalysisTreeBase");
-  gSystem->Load("libAnalysisTreeInfra");
-  gSystem->Load("libAnalysisTreeQA");
-}

--- a/src/EntryConfig.cpp
+++ b/src/EntryConfig.cpp
@@ -175,4 +175,4 @@ std::string EntryConfig::GetDirectoryName() const {
   return name;
 }
 
-} // namespace AnalysisTree::QA
+}// namespace AnalysisTree::QA

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -169,7 +169,7 @@ TDirectory* Task::MkMultiLevelDir(TFile* file, const std::string& name) const {
 }
 
 void Task::CreateOutputFileIfNotYet() {
-  if (out_file_ == nullptr) out_file_ = new TFile(out_file_name_.c_str(), "recreate");
+  if (out_file_ == nullptr) out_file_ = new TFile(out_file_name_.c_str(), out_file_option_.c_str());
 }
 
 } // namespace AnalysisTree::QA

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -8,7 +8,7 @@ size_t Task::AddH1(const std::string& name, const Axis& x, Cuts* cuts, Variable 
   CreateOutputFileIfNotYet();
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, weight, name, cuts, false);
-  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  const std::string dirName = ConstructOutputDirectoryName();
   TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -25,7 +25,7 @@ size_t Task::AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* 
   CreateOutputFileIfNotYet();
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, y, weight, name, cuts);
-  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  const std::string dirName = ConstructOutputDirectoryName();
   TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -42,7 +42,7 @@ size_t Task::AddProfile(const std::string& name, const Axis& x, const Axis& y, C
   CreateOutputFileIfNotYet();
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, y, weight, name, cuts, true);
-  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  const std::string dirName = ConstructOutputDirectoryName();
   TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -59,7 +59,7 @@ size_t Task::AddIntegral(const std::string& name, const Axis& x, Cuts* cuts, Var
   CreateOutputFileIfNotYet();
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, weight, name, cuts, true);
-  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  const std::string dirName = ConstructOutputDirectoryName();
   TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -75,7 +75,7 @@ size_t Task::AddIntegral(const Axis& x, Cuts* cuts, Variable weight) {
 size_t Task::AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x, Cuts* cuts_y) {
   CreateOutputFileIfNotYet();
   entries_.emplace_back(x, cuts_x, y, cuts_y);
-  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  const std::string dirName = ConstructOutputDirectoryName();
   TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
@@ -170,6 +170,14 @@ TDirectory* Task::MkMultiLevelDir(TFile* file, const std::string& name) const {
 
 void Task::CreateOutputFileIfNotYet() {
   if (out_file_ == nullptr) out_file_ = new TFile(out_file_name_.c_str(), out_file_option_.c_str());
+}
+
+std::string Task::ConstructOutputDirectoryName() {
+  const std::string entryName = entries_.back().GetDirectoryName();
+  std::string dirName = toplevel_dir_name_.empty() ? entryName : toplevel_dir_name_;
+  if(is_append_dir_name_with_entry_name_ && !toplevel_dir_name_.empty()) dirName.append("/" + entryName);
+
+  return dirName;
 }
 
 }// namespace AnalysisTree::QA

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -9,7 +9,7 @@ size_t Task::AddH1(const std::string& name, const Axis& x, Cuts* cuts, Variable 
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, weight, name, cuts, false);
   const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
-  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
+  TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
@@ -26,7 +26,7 @@ size_t Task::AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* 
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, y, weight, name, cuts);
   const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
-  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
+  TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
@@ -43,7 +43,7 @@ size_t Task::AddProfile(const std::string& name, const Axis& x, const Axis& y, C
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, y, weight, name, cuts, true);
   const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
-  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
+  TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
@@ -60,7 +60,7 @@ size_t Task::AddIntegral(const std::string& name, const Axis& x, Cuts* cuts, Var
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, weight, name, cuts, true);
   const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
-  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
+  TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
@@ -76,7 +76,7 @@ size_t Task::AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x, Cuts* cuts_
   CreateOutputFileIfNotYet();
   entries_.emplace_back(x, cuts_x, y, cuts_y);
   const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
-  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
+  TDirectory* dir = MkMultiLevelDir(out_file_, dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id_x = AddEntry(AnalysisEntry({entries_.back().GetVariables()[0]}, cuts_x));
@@ -145,7 +145,7 @@ void Task::Finish() {
 }
 
 TDirectory* Task::MkMultiLevelDir(TFile* file, const std::string& name) const {
-  auto splitBySlash = [] (const std::string& str) {
+  auto splitBySlash = [](const std::string& str) {
     std::vector<std::string> result;
     std::stringstream ss(str);
     std::string item;
@@ -172,5 +172,4 @@ void Task::CreateOutputFileIfNotYet() {
   if (out_file_ == nullptr) out_file_ = new TFile(out_file_name_.c_str(), out_file_option_.c_str());
 }
 
-} // namespace AnalysisTree::QA
-
+}// namespace AnalysisTree::QA

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -175,7 +175,7 @@ void Task::CreateOutputFileIfNotYet() {
 std::string Task::ConstructOutputDirectoryName() {
   const std::string entryName = entries_.back().GetDirectoryName();
   std::string dirName = toplevel_dir_name_.empty() ? entryName : toplevel_dir_name_;
-  if(is_append_dir_name_with_entry_name_ && !toplevel_dir_name_.empty()) dirName.append("/" + entryName);
+  if (is_append_dir_name_with_entry_name_ && !toplevel_dir_name_.empty()) dirName.append("/" + entryName);
 
   return dirName;
 }

--- a/src/Task.cpp
+++ b/src/Task.cpp
@@ -8,7 +8,8 @@ size_t Task::AddH1(const std::string& name, const Axis& x, Cuts* cuts, Variable 
   CreateOutputFileIfNotYet();
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, weight, name, cuts, false);
-  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
@@ -24,7 +25,8 @@ size_t Task::AddH2(const std::string& name, const Axis& x, const Axis& y, Cuts* 
   CreateOutputFileIfNotYet();
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, y, weight, name, cuts);
-  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
@@ -40,7 +42,8 @@ size_t Task::AddProfile(const std::string& name, const Axis& x, const Axis& y, C
   CreateOutputFileIfNotYet();
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, y, weight, name, cuts, true);
-  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
@@ -56,7 +59,8 @@ size_t Task::AddIntegral(const std::string& name, const Axis& x, Cuts* cuts, Var
   CreateOutputFileIfNotYet();
   weight.IfEmptyVariableConvertToOnes(x);
   entries_.emplace_back(x, weight, name, cuts, true);
-  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id = AddEntry(AnalysisEntry(entries_.back().GetVariables(), entries_.back().GetEntryCuts(), entries_.back().GetVariableForWeight()));
@@ -71,7 +75,8 @@ size_t Task::AddIntegral(const Axis& x, Cuts* cuts, Variable weight) {
 size_t Task::AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x, Cuts* cuts_y) {
   CreateOutputFileIfNotYet();
   entries_.emplace_back(x, cuts_x, y, cuts_y);
-  TDirectory* dir = MkMultiLevelDir(out_file_, toplevel_dir_name_ + "/" + entries_.back().GetDirectoryName());
+  const std::string dirName = toplevel_dir_name_.empty() ? entries_.back().GetDirectoryName() : toplevel_dir_name_;
+  TDirectory* dir = MkMultiLevelDir(out_file_,  dirName);
   ANALYSISTREE_UTILS_VISIT(setdirectory_struct(dir), entries_.back().GetPlot());
   ANALYSISTREE_UTILS_VISIT(setname_struct(entries_.back().GetName()), entries_.back().GetPlot());
   auto var_id_x = AddEntry(AnalysisEntry({entries_.back().GetVariables()[0]}, cuts_x));

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -56,8 +56,14 @@ class Task : public AnalysisTask {
     out_file_name_ = std::move(name);
     out_file_option_ = std::move(option);
   }
-  void SetTopLevelDirName(const std::string& name) { toplevel_dir_name_ = name; }
-  void ResetTopLevelDirName() { toplevel_dir_name_ = ""; }
+  void SetTopLevelDirName(const std::string& name, bool is_append_dir_name_with_entry_name=false) {
+    toplevel_dir_name_ = name;
+    is_append_dir_name_with_entry_name_ = is_append_dir_name_with_entry_name;
+  }
+  void ResetTopLevelDirName() {
+    toplevel_dir_name_ = "";
+    is_append_dir_name_with_entry_name_ = false;
+  }
 
  private:
   void FillIntegral(EntryConfig& plot);
@@ -72,12 +78,14 @@ class Task : public AnalysisTask {
   }
 
   void CreateOutputFileIfNotYet();
+  std::string ConstructOutputDirectoryName();
 
   std::vector<EntryConfig> entries_{};
   std::map<std::string, TDirectory*> dir_map_{};
   std::string out_file_name_{"QA.root"};
   std::string out_file_option_{"recreate"};
   std::string toplevel_dir_name_{""};
+  bool is_append_dir_name_with_entry_name_{false};
   TFile* out_file_{nullptr};
 
   ClassDefOverride(Task, 1);

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -52,7 +52,7 @@ class Task : public AnalysisTask {
   size_t AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x = nullptr, Cuts* cuts_y = nullptr);
 
   std::vector<EntryConfig>& Entries() { return entries_; }
-  void SetOutputFileName(std::string name, std::string option="recreate") {
+  void SetOutputFileName(std::string name, std::string option = "recreate") {
     out_file_name_ = std::move(name);
     out_file_option_ = std::move(option);
   }
@@ -65,7 +65,7 @@ class Task : public AnalysisTask {
 
   template<typename T>
   TDirectory* MkDirIfNotExists(T* fod, std::string name) const {
-    if(fod == nullptr) throw std::runtime_error("Task::MkDirIfNotExists(): file or directory ptr is null");
+    if (fod == nullptr) throw std::runtime_error("Task::MkDirIfNotExists(): file or directory ptr is null");
     TDirectory* result = fod->GetDirectory(name.c_str());
     if (result == nullptr) result = fod->mkdir(name.c_str());
     return result;

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -52,7 +52,10 @@ class Task : public AnalysisTask {
   size_t AddIntegral(const Axis& x, const Axis& y, Cuts* cuts_x = nullptr, Cuts* cuts_y = nullptr);
 
   std::vector<EntryConfig>& Entries() { return entries_; }
-  void SetOutputFileName(std::string name) { out_file_name_ = std::move(name); }
+  void SetOutputFileName(std::string name, std::string option="recreate") {
+    out_file_name_ = std::move(name);
+    out_file_option_ = std::move(option);
+  }
   void SetTopLevelDirName(const std::string& name) { toplevel_dir_name_ = name; }
   void ResetTopLevelDirName() { toplevel_dir_name_ = ""; }
 
@@ -73,6 +76,7 @@ class Task : public AnalysisTask {
   std::vector<EntryConfig> entries_{};
   std::map<std::string, TDirectory*> dir_map_{};
   std::string out_file_name_{"QA.root"};
+  std::string out_file_option_{"recreate"};
   std::string toplevel_dir_name_{""};
   TFile* out_file_{nullptr};
 

--- a/src/Task.hpp
+++ b/src/Task.hpp
@@ -56,7 +56,7 @@ class Task : public AnalysisTask {
     out_file_name_ = std::move(name);
     out_file_option_ = std::move(option);
   }
-  void SetTopLevelDirName(const std::string& name, bool is_append_dir_name_with_entry_name=false) {
+  void SetTopLevelDirName(const std::string& name, bool is_append_dir_name_with_entry_name = false) {
     toplevel_dir_name_ = name;
     is_append_dir_name_with_entry_name_ = is_append_dir_name_with_entry_name;
   }


### PR DESCRIPTION
**Major changes**:
1. Enabled writing the QA output to already existing file (use `Task::SetOutputFileName(fileName, "update")` function) - useful when the QA consists of several different `QA::Task`s taking as an input different file lists, but the output should be written into the same file.
2. Made flexible using custom or entry-driven naming of output `TDirectory`:
- output `TDirectory` name is equal to `EntryConfig`'s name - default;
- output `TDirectory` name is set by user - use `Task::SetTopLevelDirName(dirname, false)` or just `Task::SetTopLevelDirName(dirname)` function;
- output `TDirectory` name is set by user and then appended with `EntryConfig`'s name - use `Task::SetTopLevelDirName(dirname, true)` function.
For more details see the [PR](https://github.com/HeavyIonAnalysis/AnalysisTreeQA/pull/30) where `Task::SetOutputFileName()` was initially introduced.

**Minor changes**:
Removed obsolete scripts and macros.